### PR TITLE
Add option to change planning time.

### DIFF
--- a/airo_planner/ompl/dual_arm_ompl_planner.py
+++ b/airo_planner/ompl/dual_arm_ompl_planner.py
@@ -42,10 +42,14 @@ class DualArmOmplPlanner(DualArmPlanner, MultipleGoalPlanner):
         choose_path_fn: JointPathChooserType = choose_shortest_path,
         degrees_of_freedom_left: int = 6,
         degrees_of_freedom_right: int = 6,
+        allowed_planning_time: float = 1.0
     ):
+        
+        # Planner properties
         self.is_state_valid_fn = is_state_valid_fn
         self.inverse_kinematics_left_fn = inverse_kinematics_left_fn
         self.inverse_kinematics_right_fn = inverse_kinematics_right_fn
+        self.allowed_planning_time = allowed_planning_time
 
         self.degrees_of_freedom: int = degrees_of_freedom_left + degrees_of_freedom_right
         self.degrees_of_freedom_left: int = degrees_of_freedom_left
@@ -216,7 +220,7 @@ class DualArmOmplPlanner(DualArmPlanner, MultipleGoalPlanner):
         )
 
         # Run planning algorithm
-        path = solve_and_smooth_path(simple_setup)
+        path = solve_and_smooth_path(simple_setup, self.allowed_planning_time)
 
         if path is None:
             start_configuration = stack_joints(start_configuration_left, start_configuration_right)

--- a/airo_planner/ompl/dual_arm_ompl_planner.py
+++ b/airo_planner/ompl/dual_arm_ompl_planner.py
@@ -42,9 +42,9 @@ class DualArmOmplPlanner(DualArmPlanner, MultipleGoalPlanner):
         choose_path_fn: JointPathChooserType = choose_shortest_path,
         degrees_of_freedom_left: int = 6,
         degrees_of_freedom_right: int = 6,
-        allowed_planning_time: float = 1.0
+        allowed_planning_time: float = 1.0,
     ):
-        
+
         # Planner properties
         self.is_state_valid_fn = is_state_valid_fn
         self.inverse_kinematics_left_fn = inverse_kinematics_left_fn

--- a/airo_planner/ompl/mobile_platform_ompl_planner.py
+++ b/airo_planner/ompl/mobile_platform_ompl_planner.py
@@ -16,9 +16,12 @@ class MobilePlatformOmplPlanner(MobilePlatformPlanner):
     This can be useful for benchmarking with the OMPL benchmarking tools.
     """
 
-    def __init__(self, is_state_valid_fn: JointConfigurationCheckerType):
+    def __init__(self, is_state_valid_fn: JointConfigurationCheckerType, allowed_planning_time: float = 1.0):
         # TODO: JointConfigurationCheckerType is not ideal here, should be a new type or rename this type?
         self.is_state_valid_fn = is_state_valid_fn
+
+        # Planning options
+        self.allowed_planning_time = allowed_planning_time
 
         # TODO: Allow user to set these bounds.
         joint_bounds = (np.array([-10.0, -10.0, -4 * np.pi]), np.array([10.0, 10.0, 4 * np.pi]))
@@ -32,7 +35,7 @@ class MobilePlatformOmplPlanner(MobilePlatformPlanner):
         goal_state = state_to_ompl(goal_pose, space)
         self._simple_setup.setStartAndGoalStates(start_state, goal_state)
 
-        path = solve_and_smooth_path(self._simple_setup)
+        path = solve_and_smooth_path(self._simple_setup, self.allowed_planning_time)
 
         if path is None:
             raise NoPathFoundError(start_pose, goal_pose)

--- a/airo_planner/ompl/single_arm_ompl_planner.py
+++ b/airo_planner/ompl/single_arm_ompl_planner.py
@@ -49,6 +49,7 @@ class SingleArmOmplPlanner(SingleArmPlanner, MultipleGoalPlanner):
         rank_goal_configurations_fn: JointConfigurationsModifierType | None = None,
         choose_path_fn: JointPathChooserType = choose_shortest_path,
         degrees_of_freedom: int = 6,
+        allowed_planning_time: float = 1.0,
     ):
         """Instiatiate a single-arm motion planner that uses OMPL. This creates
         a SimpleSetup object. Note that planning to TCP poses is only possible
@@ -68,6 +69,7 @@ class SingleArmOmplPlanner(SingleArmPlanner, MultipleGoalPlanner):
         self.inverse_kinematics_fn = inverse_kinematics_fn
 
         # Planning parameters
+        self.allowed_planning_time = allowed_planning_time
         self._degrees_of_freedom = degrees_of_freedom
         if joint_bounds is None:
             self.joint_bounds = uniform_symmetric_joint_bounds(self._degrees_of_freedom)
@@ -119,7 +121,7 @@ class SingleArmOmplPlanner(SingleArmPlanner, MultipleGoalPlanner):
         self._set_start_and_goal_configurations(start_configuration, goal_configuration)
         simple_setup = self._simple_setup
 
-        path = solve_and_smooth_path(simple_setup)
+        path = solve_and_smooth_path(simple_setup, self.allowed_planning_time)
 
         if path is None:
             raise NoPathFoundError(start_configuration, goal_configuration)

--- a/airo_planner/ompl/utilities.py
+++ b/airo_planner/ompl/utilities.py
@@ -84,11 +84,11 @@ def create_simple_setup(
     return simple_setup
 
 
-def solve_and_smooth_path(simple_setup: og.SimpleSetup) -> JointPathType | None:
+def solve_and_smooth_path(simple_setup: og.SimpleSetup, allowed_planning_time: float = 1.0) -> JointPathType | None:
     # Should be called after start and goal have been set
 
     # Run planning algorithm
-    simple_setup.solve()
+    simple_setup.solve(allowed_planning_time)
 
     if not simple_setup.haveExactSolutionPath():
         return None

--- a/airo_planner/selection/goal_selection.py
+++ b/airo_planner/selection/goal_selection.py
@@ -21,7 +21,7 @@ def rank_by_distance_to_desirable_configurations(
         distances_to_desirable = [
             np.linalg.norm(config - desirable_config) for desirable_config in desirable_configurations
         ]
-        min_distance = min(distances_to_desirable)
+        min_distance = np.min(distances_to_desirable)
         distances.append(min_distance)
 
     ranked_configurations = [x for _, x in sorted(zip(distances, configurations))]


### PR DESCRIPTION
In some cases, it can be beneficial to allow an OMPL optimization planner (PRMstar, etc.) to run for a long time. This is especially the case if you know what two joint configurations you want to move between the two in the most optimal way.

This code simply allows the user to specify a new argument `allowed_planning_time` in all the arm planner objects. The default 1.0 seconds is kept so existing code will function exactly the same.