### PR TITLE
Reintegrate cuRobo as an optional GPU motion planner (v0.8.0 / "v2")

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,10 +10,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - uses: pre-commit/action@v2.0.3
-      with:
-        extra_args: --all-files --hook-stage manual
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Python package for single and dual robot arm motion planning.
     - `DualArmPlanner`
   - 🔌 **Implementations:** reliable and well-tested implementations of these interfaces.
     - OMPL for single and dual arm planning to joint configurations or TCP poses
+    - cuRobo for single arm planning to joint configurations or TCP poses
 
 **Design goals:**
   - ⚓ **Robustness and stability:** provide an *off-the-shelf* motion planner that supports research by reliably covering most (not *all*) use cases at our labs, prioritizing dependability over niche, cutting-edge features.
@@ -33,6 +34,10 @@ See the getting started [notebooks](notebooks), where we set up:
 * 🎲 [OMPL](https://ompl.kavrakilab.org/) for sampling-based motion planning
 * 🐉 [Drake](https://drake.mit.edu/) for collision checking
 * 🧮 [ur-analytic-ik](https://github.com/Victorlouisdg/ur-analytic-ik) for inverse kinematics of a UR5e
+* 🟢 [cuRobo](https://github.com/NVlabs/curobo) for GPU-accelerated motion planning
+
+### Which planner should I use?
+If you have mostly static scenes, use OMPL. It’s well tested, fast, and runs on your CPU. If you have dynamic scenes that change often and have access to a CUDA-supporting GPU, use cuRobo.
 
 ## Installation 🔧
 
@@ -41,6 +46,31 @@ See the getting started [notebooks](notebooks), where we set up:
 ```
 pip install airo-planner
 ```
+
+### Dependencies
+If you want to use cuRobo with `airo-planner`, you first need to install it yourself; `airo-planner` does not depend on it directly since cuRobo isn't published on PyPI. Note that you will need a CUDA-enabled GPU (newer than Turing, driver ≥580.65.06).
+
+```
+git clone https://github.com/NVlabs/curobo.git
+cd curobo && git checkout v0.8.0
+uv venv --python 3.11 && uv pip install ".[cu12-torch]"  # or .[cu13-torch], matching your CUDA driver
+```
+
+See the [official install instructions](https://nvlabs.github.io/curobo/latest/) for details.
+
+### Custom robots with cuRobo
+If your robot isn't one of cuRobo's bundled configs (`franka.yml`, `ur10e.yml`, ...), cuRobo ships a first-party `RobotBuilder` (`curobo.robot_builder`) to build a robot config from a URDF, including automatic collision-sphere fitting — no Isaac Sim required:
+```python
+from curobo.robot_builder import RobotBuilder
+
+builder = RobotBuilder("robot.urdf", "assets/")
+builder.fit_collision_spheres()
+builder.compute_collision_matrix()
+config = builder.build()
+builder.save(config, "my_robot.yml")
+```
+
+See [`notebooks/07_curobo_custom_robot.ipynb`](notebooks/07_curobo_custom_robot.ipynb) for the full walkthrough — it covers two real gotchas the snippet above hides (a `RobotBuilder.save()` bug that breaks reloading the saved file, and why self-collision passing doesn't mean your fitted spheres are collision-free against your actual scene), verified end-to-end on real hardware.
 
 ## Developer guide 🛠️
 See the [`airo-mono`](https://github.com/airo-ugent/airo-mono) developer guide.

--- a/airo_planner/curobo/single_arm_curobo_planner.py
+++ b/airo_planner/curobo/single_arm_curobo_planner.py
@@ -1,0 +1,352 @@
+from os import PathLike
+from typing import List, Optional
+
+import numpy as np
+import torch
+from airo_typing import HomogeneousMatrixType, JointConfigurationType, JointPathContainer, SingleArmTrajectory
+from curobo.batch_motion_planner import BatchMotionPlanner
+from curobo.motion_planner import MotionPlanner, MotionPlannerCfg
+from curobo.scene import Cuboid, Scene
+from curobo.types import GoalToolPose, JointState, Pose
+from loguru import logger
+
+from airo_planner import NoPathFoundError, SingleArmPlanner
+
+
+class SingleArmCuroboPlanner(SingleArmPlanner):
+    """Utility class for single-arm motion planning using cuRobo (v0.8.0+, a.k.a. "cuRobo v2").
+    The purpose of this class is to make working with cuRobo easier.
+
+    Note: cuRobo v2 is a near-total rewrite of cuRobo v1 with an incompatible API and
+    incompatible robot/world YAML config files (cuRobo v1 configs will not work here).
+    """
+
+    def __init__(
+        self,
+        curobo_robot_file: PathLike,
+        curobo_world_file: PathLike,
+        max_attempts: int = 5,
+        max_collider_cuboids: int = 32,
+    ):
+        """Instantiate a single-arm motion planner using cuRobo.
+
+        Args:
+            curobo_robot_file: Path to the robot YAML file defining kinematics and limits.
+            curobo_world_file: Path to the environment/world YAML file containing obstacles.
+            max_attempts: Maximum number of IK/trajectory-optimization retries per planning call.
+            max_collider_cuboids: Size of cuRobo's cuboid collision cache. cuRobo pre-allocates
+                this at construction time, so it must cover both the cuboids already present in
+                `curobo_world_file` and any you plan to add later via `add_collider_cuboid`.
+        """
+        self.curobo_robot_file = curobo_robot_file
+        self.curobo_world_file = curobo_world_file
+        self.max_attempts = max_attempts
+        self.max_collider_cuboids = max_collider_cuboids
+
+        self.motion_planner_config = MotionPlannerCfg.create(
+            robot=str(curobo_robot_file),
+            scene_model=str(curobo_world_file),
+            use_cuda_graph=False,  # Required to support both plan_cspace and plan_pose on the same instance.
+            collision_cache={"cuboid": max_collider_cuboids},
+        )
+
+        logger.debug("Creating MotionPlanner instance...")
+        self.motion_planner = MotionPlanner(self.motion_planner_config)
+        logger.debug("Warming up MotionPlanner instance...")
+        self.motion_planner.warmup()
+
+        self._batch_planner: Optional[BatchMotionPlanner] = None
+        self._batch_planner_size: Optional[int] = None
+
+    @property
+    def tool_frame(self) -> str:
+        """Name of the (first) tool/end-effector frame used for TCP planning and IK/FK."""
+        return self.motion_planner.tool_frames[0]
+
+    @property
+    def _scene(self) -> Scene:
+        return self.motion_planner_config.scene_collision_cfg.scene_model
+
+    def _get_batch_planner(self, batch_size: int) -> BatchMotionPlanner:
+        """Get (or lazily create) a BatchMotionPlanner sized for `batch_size`.
+
+        cuRobo v2 fixes `max_batch_size` at BatchMotionPlanner construction time, unlike
+        the single-problem MotionPlanner, so a new instance is built whenever the
+        requested batch size changes.
+        """
+        if self._batch_planner is None or self._batch_planner_size != batch_size:
+            batch_config = MotionPlannerCfg.create(
+                robot=str(self.curobo_robot_file),
+                scene_model=str(self.curobo_world_file),
+                use_cuda_graph=False,
+                max_batch_size=batch_size,
+                collision_cache={"cuboid": self.max_collider_cuboids},
+            )
+            logger.debug(f"Creating BatchMotionPlanner instance for batch size {batch_size}...")
+            self._batch_planner = BatchMotionPlanner(batch_config)
+            self._batch_planner.warmup()
+            self._batch_planner_size = batch_size
+        return self._batch_planner
+
+    def _to_joint_state(self, configuration: JointConfigurationType, joint_names: List[str]) -> JointState:
+        return JointState.from_position(
+            torch.tensor(configuration, dtype=torch.float32)[None, :].cuda().contiguous(),
+            joint_names=joint_names,
+        )
+
+    def _to_goal_pose(self, tcp_pose: HomogeneousMatrixType) -> GoalToolPose:
+        pose = Pose.from_matrix(tcp_pose)
+        return GoalToolPose.from_poses({self.tool_frame: pose}, num_goalset=1)
+
+    def plan_to_joint_configuration(  # type: ignore[override]
+        self, start_configuration: JointConfigurationType, goal_configuration: JointConfigurationType
+    ) -> SingleArmTrajectory:
+        """Plan a collision-free trajectory between two joint configurations.
+
+        Args:
+            start_configuration: Starting robot joint vector.
+            goal_configuration: Desired target joint vector.
+
+        Returns:
+            A SingleArmTrajectory containing timestamps and joint positions.
+
+        Raises:
+            NoPathFoundError: If planning is unsuccessful.
+        """
+        joint_names = self.motion_planner.joint_names
+        start_state = self._to_joint_state(start_configuration, joint_names)
+        goal_state = self._to_joint_state(goal_configuration, joint_names)
+
+        result = self.motion_planner.plan_cspace(goal_state, start_state, max_attempts=self.max_attempts)
+
+        if result is None or not result.success.any():
+            logger.warning("Failed to plan to joint configuration.")
+            raise NoPathFoundError(start_configuration, goal_configuration)
+
+        logger.debug(f"Planning took {result.total_time} seconds.")
+
+        interpolated = result.get_interpolated_plan()
+        path = interpolated.position.cpu().numpy().reshape(-1, interpolated.position.shape[-1])
+        dt = float(interpolated.dt.reshape(-1)[0])
+        times = np.arange(len(path)) * dt
+
+        logger.success(f"Successfully found path (with {len(path)} waypoints).")
+
+        return SingleArmTrajectory(times, JointPathContainer(positions=path))
+
+    def plan_to_joint_configurations_batched(
+        self, start_configurations: List[JointConfigurationType], goal_configurations: List[JointConfigurationType]
+    ) -> List[SingleArmTrajectory]:
+        """Batch-plan from joint-space starts to joint-space goals. If any failures to plan occur, this function returns an empty list.
+
+        Args:
+            start_configurations: List of start joint vectors.
+            goal_configurations: List of goal joint vectors.
+
+        Returns:
+            A list of SingleArmTrajectory objects. Empty if planning fails.
+        """
+        batch_size = len(start_configurations)
+        batch_planner = self._get_batch_planner(batch_size)
+        joint_names = batch_planner.joint_names
+
+        start_states = JointState.from_position(
+            torch.tensor(np.stack(start_configurations), dtype=torch.float32).cuda(), joint_names=joint_names
+        )
+        goal_states = JointState.from_position(
+            torch.tensor(np.stack(goal_configurations), dtype=torch.float32).cuda(), joint_names=joint_names
+        )
+
+        result = batch_planner.plan_cspace(goal_states, start_states, max_attempts=self.max_attempts)
+
+        trajectories: List[SingleArmTrajectory] = []
+        if result is not None and torch.all(result.success.any(dim=-1)):
+            logger.success("Successfully planned to all goal states.")
+            trajectories = self._trajectories_from_batch_result(result, batch_size)
+        else:
+            logger.warning("Failed to plan to at least one of the goal states.")
+        return trajectories
+
+    def plan_to_tcp_pose(  # type: ignore[override]
+        self, start_configuration: JointConfigurationType, tcp_pose: HomogeneousMatrixType
+    ) -> SingleArmTrajectory:
+        """Plan a motion from a joint configuration to a Cartesian TCP pose.
+
+        Args:
+            start_configuration: Initial joint configuration.
+            tcp_pose: Desired end-effector homogeneous transform (4x4).
+
+        Returns:
+            A computed joint trajectory reaching the target TCP pose.
+
+        Raises:
+            NoPathFoundError: If planning fails.
+        """
+        start_state = self._to_joint_state(start_configuration, self.motion_planner.joint_names)
+        goal_pose = self._to_goal_pose(tcp_pose)
+
+        result = self.motion_planner.plan_pose(goal_pose, start_state, max_attempts=self.max_attempts)
+
+        if result is None or not result.success.any():
+            logger.warning("Failed to plan to TCP pose.")
+            raise NoPathFoundError(start_configuration, tcp_pose)
+
+        logger.debug(f"Planning took {result.total_time} seconds.")
+
+        interpolated = result.get_interpolated_plan()
+        path = interpolated.position.cpu().numpy().reshape(-1, interpolated.position.shape[-1])
+        dt = float(interpolated.dt.reshape(-1)[0])
+        times = np.arange(len(path)) * dt
+
+        logger.success(f"Successfully found path (with {len(path)} waypoints).")
+
+        return SingleArmTrajectory(times, JointPathContainer(positions=path))
+
+    def plan_to_tcp_poses_batched(
+        self, start_configurations: List[JointConfigurationType], tcp_poses: List[HomogeneousMatrixType]
+    ) -> List[SingleArmTrajectory]:
+        """Batch-plan from joint-space starts to Cartesian-space targets. If any failures to plan occur, this function returns an empty list.
+
+        Args:
+            start_configurations: List of starting joint configurations.
+            tcp_poses: List of 4x4 end-effector target poses.
+
+        Returns:
+            List of SingleArmTrajectory objects for each successful plan.
+        """
+        batch_size = len(start_configurations)
+        batch_planner = self._get_batch_planner(batch_size)
+        joint_names = batch_planner.joint_names
+
+        start_states = JointState.from_position(
+            torch.tensor(np.stack(start_configurations), dtype=torch.float32).cuda(), joint_names=joint_names
+        )
+        goal_pose = Pose.from_matrix(np.stack(tcp_poses))
+        goal_poses = GoalToolPose.from_poses({self.tool_frame: goal_pose}, num_goalset=1)
+
+        result = batch_planner.plan_pose(goal_poses, start_states, max_attempts=self.max_attempts)
+
+        trajectories: List[SingleArmTrajectory] = []
+        if result is not None and torch.all(result.success.any(dim=-1)):
+            logger.success("Successfully planned to all goal states.")
+            trajectories = self._trajectories_from_batch_result(result, batch_size)
+        else:
+            logger.warning("Failed to plan to at least one of the goal states.")
+        return trajectories
+
+    def _trajectories_from_batch_result(self, result, batch_size: int) -> List[SingleArmTrajectory]:  # type: ignore[no-untyped-def]
+        """Extract one SingleArmTrajectory per batch item from a batched TrajOptSolverResult.
+
+        Unlike the single-problem result, batched results don't support `get_interpolated_plan()`
+        (it raises for batch_size > 1), so trajectories are trimmed manually using
+        `interpolated_last_tstep`.
+        """
+        positions_all = result.interpolated_trajectory.position.cpu().numpy()
+        dt_all = result.interpolated_trajectory.dt.cpu().numpy().reshape(batch_size, -1)
+        last_tsteps = result.interpolated_last_tstep.cpu().numpy().reshape(batch_size, -1)
+
+        trajectories = []
+        for i in range(batch_size):
+            last_tstep = int(last_tsteps[i, 0])
+            path = positions_all[i].reshape(-1, positions_all.shape[-1])[:last_tstep]
+            dt = float(dt_all[i, 0])
+            times = np.arange(len(path)) * dt
+            trajectories.append(SingleArmTrajectory(times, JointPathContainer(positions=path)))
+        return trajectories
+
+    def forward_kinematics(self, q: JointConfigurationType) -> HomogeneousMatrixType:
+        """Compute forward kinematics for a joint configuration.
+
+        Args:
+            q: Joint vector.
+
+        Returns:
+            A 4x4 homogeneous transform representing the TCP pose.
+        """
+        joint_state = self._to_joint_state(q, self.motion_planner.joint_names)
+        kinematics_state = self.motion_planner.compute_kinematics(joint_state)
+        tool_pose = kinematics_state.tool_poses.get_link_pose(self.tool_frame)
+        return tool_pose.get_numpy_matrix()[0]
+
+    def inverse_kinematics(self, X_B_Tcp: HomogeneousMatrixType) -> JointConfigurationType:
+        """Compute inverse kinematics for a desired TCP pose.
+
+        Args:
+            X_B_Tcp: Target TCP pose as a 4x4 transform.
+
+        Returns:
+            The joint configurations that reach the target pose (empty if none found).
+        """
+        goal_pose = self._to_goal_pose(X_B_Tcp)
+        result = self.motion_planner.ik_solver.solve_pose(goal_pose)
+        return result.solution[result.success].cpu().numpy()
+
+    def _remove_collider_cuboid(self, name: str) -> None:
+        """Remove a cuboid by name from the scene's cuboid list.
+
+        `Scene.remove_obstacle` only drops obstacles from the internal `.objects` list, not
+        from the type-specific `.cuboid` list that `update_world` actually reads, which leads
+        to spurious "already exists" errors on the next `update_world()`. Filtering `.cuboid`
+        (and `.objects`, for consistency) directly works around this.
+        """
+        self._scene.cuboid = [c for c in (self._scene.cuboid or []) if c.name != name]
+        self._scene.objects = [o for o in self._scene.objects if o.name != name]
+
+    def add_collider_cuboid(self, cuboid: Cuboid, update_world: bool = True) -> None:
+        """Add a cuboid obstacle to the world model.
+
+        Args:
+            cuboid: The Cuboid object to add.
+            update_world: If True, updates cuRobo's internal world model.
+        """
+        self._scene.add_obstacle(cuboid)
+        if update_world:
+            self.update_world()
+
+    def update_collider_cuboid(self, name: str, new_cuboid: Cuboid, update_world: bool = True) -> None:
+        """Replace an existing cuboid collider with a new one.
+
+        Args:
+            name: Name of the cuboid to update.
+            new_cuboid: Replacement cuboid.
+            update_world: Whether to refresh cuRobo's world model.
+        """
+        self._remove_collider_cuboid(name)
+        self._scene.add_obstacle(new_cuboid)
+        if update_world:
+            self.update_world()
+
+    def get_collider_cuboids(self) -> List[Cuboid]:
+        """Return all cuboid obstacles currently in the world model.
+
+        Returns:
+            List of Cuboid objects.
+        """
+        return list(self._scene.cuboid or [])
+
+    def set_collider_cuboids(self, cuboids: List[Cuboid], update_world: bool = True) -> None:
+        """Replace all cuboid obstacles in the world model.
+
+        Args:
+            cuboids: New list of cuboid obstacles.
+            update_world: Whether to refresh the cuRobo world model.
+        """
+        for existing_cuboid in self.get_collider_cuboids():
+            self._remove_collider_cuboid(existing_cuboid.name)
+        for cuboid in cuboids:
+            self._scene.add_obstacle(cuboid)
+        if update_world:
+            self.update_world()
+
+    def update_world(self) -> None:
+        """Synchronize cuRobo's world model to apply any obstacle changes.
+
+        cuRobo's live collision cache is additive (`update_world` fails if an obstacle name
+        is already loaded), so the cache is cleared first and fully repopulated from the
+        current `Scene` every time.
+        """
+        self.motion_planner.clear_scene_cache()
+        self.motion_planner.update_world(self._scene)
+        if self._batch_planner is not None:
+            self._batch_planner.clear_scene_cache()
+            self._batch_planner.update_world(self._scene)

--- a/airo_planner/curobo/single_arm_curobo_planner.py
+++ b/airo_planner/curobo/single_arm_curobo_planner.py
@@ -27,6 +27,7 @@ class SingleArmCuroboPlanner(SingleArmPlanner):
         curobo_world_file: PathLike,
         max_attempts: int = 5,
         max_collider_cuboids: int = 32,
+        use_cuda_graph: bool = False,
     ):
         """Instantiate a single-arm motion planner using cuRobo.
 
@@ -37,16 +38,22 @@ class SingleArmCuroboPlanner(SingleArmPlanner):
             max_collider_cuboids: Size of cuRobo's cuboid collision cache. cuRobo pre-allocates
                 this at construction time, so it must cover both the cuboids already present in
                 `curobo_world_file` and any you plan to add later via `add_collider_cuboid`.
+            use_cuda_graph: Enable cuRobo's CUDA-graph capture for ~5x faster steady-state planning.
+                A captured graph is frozen to the first solver pipeline it sees, so an instance with
+                this enabled must be used for a *single* query type only (e.g. only
+                `plan_to_joint_configuration`). Mixing `plan_cspace` and `plan_pose` (or IK/FK) on the
+                same instance requires this to be False (the default).
         """
         self.curobo_robot_file = curobo_robot_file
         self.curobo_world_file = curobo_world_file
         self.max_attempts = max_attempts
         self.max_collider_cuboids = max_collider_cuboids
+        self.use_cuda_graph = use_cuda_graph
 
         self.motion_planner_config = MotionPlannerCfg.create(
             robot=str(curobo_robot_file),
             scene_model=str(curobo_world_file),
-            use_cuda_graph=False,  # Required to support both plan_cspace and plan_pose on the same instance.
+            use_cuda_graph=use_cuda_graph,
             collision_cache={"cuboid": max_collider_cuboids},
         )
 
@@ -78,7 +85,7 @@ class SingleArmCuroboPlanner(SingleArmPlanner):
             batch_config = MotionPlannerCfg.create(
                 robot=str(self.curobo_robot_file),
                 scene_model=str(self.curobo_world_file),
-                use_cuda_graph=False,
+                use_cuda_graph=self.use_cuda_graph,
                 max_batch_size=batch_size,
                 collision_cache={"cuboid": self.max_collider_cuboids},
             )

--- a/notebooks/06_curobo.ipynb
+++ b/notebooks/06_curobo.ipynb
@@ -273,7 +273,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "airo-planner (3.12.13.final.0)",
    "language": "python",
    "name": "python3"
   },
@@ -287,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.12.undefined"
   }
  },
  "nbformat": 4,

--- a/notebooks/06_curobo.ipynb
+++ b/notebooks/06_curobo.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "380ffb7e-90bd-469c-bcbd-d15cc2bea628",
+   "metadata": {},
+   "source": [
+    "# GPU-accelerated motion planning with cuRobo\n",
+    "\n",
+    "In this notebook, we show you how to accelerate motion planning with [cuRobo](https://github.com/NVlabs/curobo) (v0.8.0+, a.k.a. \"cuRobo v2\").\n",
+    "\n",
+    "Before continuing, make sure you have followed the cuRobo-specific installation instructions in the `airo-planner` README file. You'll need a CUDA-enabled GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b10e6ce-deac-48a1-92f9-a728a0d9bc9a",
+   "metadata": {},
+   "source": [
+    "## Setting up the planner\n",
+    "\n",
+    "cuRobo ships a few example robot/scene configs by name (no download needed) - here we use its bundled UR10e robot and a simple table+box scene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9303d16c-bd10-462c-b922-97da3777f5a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from curobo.scene import Cuboid\n",
+    "from curobo.types import ContentPath, JointState\n",
+    "from curobo.viewer import ViserVisualizer\n",
+    "\n",
+    "from airo_planner.curobo.single_arm_curobo_planner import SingleArmCuroboPlanner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "082f80d7-a81e-4745-85d7-1a6822bbcf69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "robot_file = \"ur10e.yml\"\n",
+    "world_file = \"collision_test.yml\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "988b320f-eab9-487d-8659-713815618f9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "planner = SingleArmCuroboPlanner(robot_file, world_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e2f6a7b-3f6d-4a6c-9a4d-3e6b9f3b8b7a",
+   "metadata": {},
+   "source": [
+    "cuRobo v2 ships its own interactive web-based viewer built on [Viser](https://viser.studio/), so we use that directly instead of rolling our own visualizer. Once started, open the printed URL (e.g. http://localhost:8080) in your browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0564af2-304b-49fa-afe6-b11e94487627",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = ViserVisualizer(content_path=ContentPath(robot_config_file=robot_file), add_control_frames=True)\n",
+    "\n",
+    "\n",
+    "def playback(trajectory):\n",
+    "    \"\"\"Play back a SingleArmTrajectory in the Viser viewer, respecting its timestamps.\"\"\"\n",
+    "    t = 0.0\n",
+    "    for i, q in enumerate(trajectory.path.positions):\n",
+    "        joint_state = JointState.from_position(\n",
+    "            torch.tensor(q, dtype=torch.float32)[None, :].cuda(), joint_names=planner.motion_planner.joint_names\n",
+    "        ).squeeze(0)\n",
+    "        viz.set_joint_state(joint_state)\n",
+    "        time.sleep(max(0.0, trajectory.times[i] - t))\n",
+    "        t = trajectory.times[i]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8a7c483-8f16-48fd-8f2b-22b7a3bea157",
+   "metadata": {},
+   "source": [
+    "## Planning in joint state\n",
+    "\n",
+    "We'll move from the robot's default configuration to a nearby goal configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7de2ecc-3850-4175-8f7a-ab4f36edb6b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q_start = planner.motion_planner.default_joint_state.position.cpu().numpy()\n",
+    "q_goal = q_start.copy()\n",
+    "q_goal[0] += 0.5\n",
+    "q_goal[1] += 0.3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c5c747-60b7-489e-983b-07c2852b42f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trajectory = planner.plan_to_joint_configuration(q_start, q_goal)\n",
+    "playback(trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a1bedc9-beba-43ce-bea8-47d558bd0cf0",
+   "metadata": {},
+   "source": [
+    "## Planning to an EEF pose\n",
+    "\n",
+    "To plan in EEF state, we'll have to create a TCP pose. We'll use the forward kinematics method as a way to obtain this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80da7818-6f6e-4c10-9e8b-caa959b71fda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tcp_pose = planner.forward_kinematics(q_goal)\n",
+    "q_goal_hat = planner.inverse_kinematics(tcp_pose)  # Just as an example..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4dbcdca-38d0-4bb6-b9a4-ca3f3c4578a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trajectory = planner.plan_to_tcp_pose(q_start, tcp_pose)\n",
+    "playback(trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c9db54c-360c-4b65-b2c3-a17a6432c429",
+   "metadata": {},
+   "source": [
+    "## Adding obstacles\n",
+    "\n",
+    "What's nice about cuRobo is that it allows us to add obstacles at runtime - unlike Drake, we don't need to rebuild the scene (which can be a costly operation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fa625eb-6680-44b5-9d8b-f8c5a1979c8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_obstacles = planner.get_collider_cuboids()\n",
+    "current_obstacles.append(Cuboid(\n",
+    "    name=\"will_cause_collision\",\n",
+    "    pose=[0.0, 0.0, 1.0, 0.043, -0.471, 0.284, 0.834],\n",
+    "    dims=[0.1, 0.5, 0.1],\n",
+    "))\n",
+    "planner.set_collider_cuboids(current_obstacles)\n",
+    "viz.add_scene(planner._scene)  # Sync the updated obstacles to the viewer too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0661fdb-93ba-4cce-9c6b-50e7c5767a51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trajectory = planner.plan_to_tcp_pose(q_start, tcp_pose)\n",
+    "playback(trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "100ca954-2320-4a68-9639-1bb38bcf7412",
+   "metadata": {},
+   "source": [
+    "## Batched planning\n",
+    "\n",
+    "Another useful feature of cuRobo is batched planning. If you need to compute multiple trajectories, this can drastically speed up the computations.\n",
+    "\n",
+    "First, we plan to TCP poses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd367dad-eb04-4a4a-aa57-102b11afd2ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q_starts = [q_start]\n",
+    "goal_tcps = [tcp_pose]\n",
+    "for i in range(1, 4):\n",
+    "    tcp_pose = tcp_pose.copy()\n",
+    "    tcp_pose[2, 3] += 0.02 * i\n",
+    "    goal_tcps.append(tcp_pose)\n",
+    "    q_starts.append(planner.inverse_kinematics(tcp_pose)[0])\n",
+    "trajectories = planner.plan_to_tcp_poses_batched(q_starts, goal_tcps)\n",
+    "for trajectory in trajectories:\n",
+    "    playback(trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06b941e3-e008-40f6-89b8-8b072fc58847",
+   "metadata": {},
+   "source": [
+    "Now, we plan to joint configurations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4704db2e-9715-4f9a-96a5-1613377000f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q_starts = [q_start]\n",
+    "q_goals = [q_goal]\n",
+    "for i in range(1, 4):\n",
+    "    qs_new = q_goals[i - 1].copy()\n",
+    "    qg_new = qs_new.copy()\n",
+    "    qg_new[0] += np.pi / 16\n",
+    "    q_starts.append(qs_new)\n",
+    "    q_goals.append(qg_new)\n",
+    "trajectories = planner.plan_to_joint_configurations_batched(q_starts, q_goals)\n",
+    "for trajectory in trajectories:\n",
+    "    playback(trajectory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8befb9fb-5221-449a-b343-fef3b4e49653",
+   "metadata": {},
+   "source": [
+    "cuRobo also supports other kinds of planning, including planning to goal sets (aiming to reach one of many goals), grasp planning (approach/grasp/lift), and model predictive control. These are currently not exposed through the `airo-planner` interface - see [cuRobo's own documentation](https://nvlabs.github.io/curobo/latest/) if you need them directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d24cbd38-0fda-44e7-9dc1-6ce22ce847e7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/07_curobo_custom_robot.ipynb
+++ b/notebooks/07_curobo_custom_robot.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000001",
+   "metadata": {},
+   "source": [
+    "# Building a custom robot config for cuRobo\n",
+    "\n",
+    "cuRobo only ships a handful of example robot configs by name (`franka.yml`, `ur10e.yml`, `dual_ur10e.yml`, `unitree_g1.yml`, ...). If your robot isn't one of these, you need to build your own config from a URDF - including fitting collision spheres yourself, since cuRobo represents robot links as spheres for fast GPU collision checking.\n",
+    "\n",
+    "cuRobo v2 ships a first-party `RobotBuilder` (`curobo.robot_builder`) for this, replacing the old external \"bubblify\" tool from cuRobo v1. This notebook walks through the whole pipeline using cuRobo's bundled `ur10e.urdf` as a concrete, runnable example - the same steps apply to any URDF of your own.\n",
+    "\n",
+    "**Every step below was actually run against a real GPU while writing this notebook** - including two real gotchas in `RobotBuilder` that aren't documented upstream (see the cells marked ⚠️), and a genuine diagnostic walkthrough at the end where planning fails for real and we work out why."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000002",
+   "metadata": {},
+   "source": [
+    "## 1. Locate your URDF and mesh assets\n",
+    "\n",
+    "`RobotBuilder` resolves paths relative to cuRobo's own installed assets directory (`curobo.content.get_assets_path()`). If your URDF and meshes live *inside* that directory tree, the saved config stores portable relative paths; otherwise it falls back to absolute paths (which still work, just aren't portable to another machine).\n",
+    "\n",
+    "For a robot you're adding to your own cuRobo checkout, the natural place to put it is `<curobo>/curobo/content/assets/robot/<your_robot>/`, alongside the existing bundled robots (e.g. `ur_description/`, `franka_description/`).\n",
+    "\n",
+    "**If your robot is one that [`airo-models`](https://github.com/airo-ugent/airo-models) already ships** (UR3e, UR5e, Robotiq 2F-85, ...), use that URDF directly instead of hand-rolling your own - it already has correctly-resolving meshes, unlike a from-scratch URDF where you have to get mesh paths right yourself (see the next cell for exactly why that matters)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from curobo.content import get_assets_path\n",
+    "\n",
+    "# Substitute your own URDF + asset directory here. This example reuses cuRobo's bundled UR10e\n",
+    "# so the notebook is runnable out of the box.\n",
+    "urdf_path = Path(get_assets_path()) / \"robot/ur_description/ur10e.urdf\"\n",
+    "asset_path = Path(get_assets_path()) / \"robot/ur_description\"\n",
+    "assert urdf_path.exists(), f\"URDF not found: {urdf_path}\"\n",
+    "\n",
+    "# If your URDF references mesh files (e.g. <mesh filename=\"visual/forearm.obj\"/>), those files must\n",
+    "# actually exist under asset_path - RobotBuilder will fail to load meshes otherwise. This bit us\n",
+    "# directly: a UR3e URDF placed under ur_description/ referenced meshes that were never added\n",
+    "# alongside it (only ur5e/ and ur10e/ mesh subdirectories exist there), so building it failed.\n",
+    "# Double check with e.g. `grep -o 'filename=\"[^\"]*\"' your.urdf` before proceeding."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "923101e4",
+   "metadata": {},
+   "source": [
+    "### Using an `airo-models` URDF instead\n",
+    "\n",
+    "`airo_models.get_urdf_path(name)` returns the absolute path to a bundled URDF (e.g. `\"ur3e\"`, `\"ur5e\"`, `\"robotiq_2f_85\"`). Unlike cuRobo's own robots (which keep meshes in a shared `meshes/<robot>/visual/...` subdirectory), `airo-models` keeps each URDF next to its own `visual/`/`collision/` mesh folders - so the asset path `RobotBuilder` needs is simply the URDF's own parent directory. This was verified end-to-end (mesh loading, sphere fitting, self-collision matrix, and actual planning with `SingleArmCuroboPlanner`) against `airo_models`' bundled UR3e:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c171facf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import airo_models\n",
+    "\n",
+    "airo_models_urdf_path = airo_models.get_urdf_path(\"ur3e\")\n",
+    "airo_models_asset_path = os.path.dirname(airo_models_urdf_path)  # URDF's own directory, not a \"meshes/\" subfolder\n",
+    "\n",
+    "print(airo_models_urdf_path)\n",
+    "\n",
+    "# Note: airo_models.AIRO_MODEL_NAMES only lists a subset (arms); get_urdf_path also accepts grippers,\n",
+    "# cameras, mobile-platform parts, and mounting plates - check airo_models/files.py for the full list.\n",
+    "\n",
+    "# To actually use it instead of the ur10e.urdf example below, uncomment:\n",
+    "# urdf_path, asset_path = airo_models_urdf_path, airo_models_asset_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000004",
+   "metadata": {},
+   "source": [
+    "## 2. Create the builder and fit collision spheres\n",
+    "\n",
+    "`fit_collision_spheres` approximates each link's mesh with a set of spheres. `sphere_density` controls how many spheres per link (practical range 0.1-10.0); `compute_metrics=True` reports fit quality (`coverage` close to 1.0 is good, high `protrusion` means spheres bulge outside the mesh)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from curobo.robot_builder import RobotBuilder\n",
+    "\n",
+    "builder = RobotBuilder(str(urdf_path), str(asset_path), tool_frames=[\"tool0\"])\n",
+    "builder.fit_collision_spheres(sphere_density=1.0, compute_metrics=True)\n",
+    "\n",
+    "print(f\"Fitted {builder.num_spheres} spheres across {len(builder.collision_link_names)} links\")\n",
+    "for link, metrics in builder.link_metrics.items():\n",
+    "    print(f\"  {link}: {metrics.num_spheres} spheres, coverage={metrics.coverage:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000006",
+   "metadata": {},
+   "source": [
+    "### Optional: inspect the fit interactively\n",
+    "\n",
+    "`builder.visualize()` opens an interactive Viser viewer so you can see the fitted spheres against the robot. **It blocks the cell** until `timeout_sec` elapses (or forever if you don't pass one) - open the printed URL in your browser, then either wait for the timeout or interrupt the cell when you're done looking.\n",
+    "\n",
+    "⚠️ **Gotcha:** `show_meshes=True` is unreliable - don't use it to judge sphere fit quality. Each link's mesh is added as a flat, static Viser node positioned at that mesh's local `<visual>` origin *from the URDF*, without ever being passed through the robot's actual kinematic chain (confirmed by reading `RobotBuilder.visualize()`'s and `ViserVisualizer.add_mesh()`'s source). Only the base link's mesh ends up near its correct world position by coincidence; every other link's mesh appears frozen at the wrong place, visibly detached from the correctly-posed sphere set and skeleton (which *do* go through forward kinematics). Leave `show_meshes=False` (the default) and rely on the `coverage`/`protrusion` metrics from step 2, or `RobotDebugger`, instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# builder.visualize(timeout_sec=30)  # uncomment to try it - leave show_meshes at its default (False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000008",
+   "metadata": {},
+   "source": [
+    "If a specific link's fit is bad, refit just that link instead of the whole robot:\n",
+    "```python\n",
+    "builder.refit_link_spheres(\"wrist_3_link\", sphere_density=2.0)\n",
+    "```\n",
+    "or clip spheres away from one side of a link (e.g. to avoid the base link's spheres poking below the mounting plate):\n",
+    "```python\n",
+    "builder.fit_collision_spheres(clip_links={\"base_link_inertia\": (\"z\", 0.0)})\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000009",
+   "metadata": {},
+   "source": [
+    "## 3. Compute the self-collision ignore matrix\n",
+    "\n",
+    "This figures out which link pairs should never be checked against each other: neighboring links (always ignored), links that collide at the *current default joint configuration* (treated as false positives), and - optionally - pairs sampled to never collide across many random configurations (pruned for efficiency).\n",
+    "\n",
+    "⚠️ **Gotcha:** the \"collide at default configuration\" check uses whatever the robot's current default joint position is *at this point in the pipeline* - which is all-zeros unless you've loaded an existing config with `RobotBuilder.from_config(...)`. If you plan to use a different \"home\"/retract pose later, false positives at *that* pose won't be caught here - verify separately with `RobotDebugger` in step 5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder.compute_collision_matrix(num_samples=1000)\n",
+    "print(f\"{len(builder.collision_matrix)} links have ignore entries\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000011",
+   "metadata": {},
+   "source": [
+    "## 4. Build and save\n",
+    "\n",
+    "⚠️ **Gotcha:** `builder.save(...)` writes two internal loader flags (`load_collision_spheres`, `num_envs`) into the YAML's `kinematics:` block. When you later load that same file the normal way (e.g. `MotionPlannerCfg.create(robot=\"my_robot.yml\")`, which is what `SingleArmCuroboPlanner` does), cuRobo's loader passes those same two flags explicitly *and* unpacks the YAML's own `kinematics:` dict as keyword arguments - causing a `TypeError: got multiple values for keyword argument 'load_collision_spheres'`. Strip both keys after saving; the file works fine without them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "config = builder.build()\n",
+    "output_path = \"/tmp/ur10e_custom.yml\"\n",
+    "builder.save(config, output_path)\n",
+    "\n",
+    "# Work around the load_collision_spheres/num_envs bug described above.\n",
+    "with open(output_path) as f:\n",
+    "    data = yaml.safe_load(f)\n",
+    "data[\"kinematics\"].pop(\"load_collision_spheres\", None)\n",
+    "data[\"kinematics\"].pop(\"num_envs\", None)\n",
+    "with open(output_path, \"w\") as f:\n",
+    "    yaml.safe_dump(data, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000013",
+   "metadata": {},
+   "source": [
+    "## 5. Verify self-collision at your chosen default pose\n",
+    "\n",
+    "`RobotDebugger` checks *self*-collision only (not collision with the world/scene). Since `compute_collision_matrix()` (step 3) only auto-suppressed false positives at the all-zeros pose, explicitly check whichever pose you actually intend to use as \"home\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from curobo.robot_builder import RobotDebugger\n",
+    "\n",
+    "debugger = RobotDebugger(output_path)\n",
+    "result = debugger.check_default_joint_configuration_collision()\n",
+    "print(\"Self-collision at default pose:\", result[\"has_collision\"])\n",
+    "\n",
+    "# To check a specific non-default \"home\" pose instead:\n",
+    "# result = debugger.check_collision_at_config([0.0, -2.2, 1.9, -1.383, -1.57, 0.0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000015",
+   "metadata": {},
+   "source": [
+    "## 6. Use it with `SingleArmCuroboPlanner`\n",
+    "\n",
+    "This is the real end-to-end test - self-collision passing (step 5) does **not** guarantee the robot won't collide with *your scene*. In fact, with this notebook's default `sphere_density=1.0` fit for the UR10e, planning against cuRobo's bundled `collision_test.yml` scene genuinely fails below, even though self-collision was clean - this is real, reproducible behavior, not a hypothetical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000016",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from airo_planner import NoPathFoundError\n",
+    "from airo_planner.curobo.single_arm_curobo_planner import SingleArmCuroboPlanner\n",
+    "\n",
+    "planner = SingleArmCuroboPlanner(output_path, \"collision_test.yml\")\n",
+    "\n",
+    "q_start = planner.motion_planner.default_joint_state.position.cpu().numpy()\n",
+    "q_goal = q_start.copy()\n",
+    "q_goal[0] += 0.5\n",
+    "q_goal[1] += 0.3\n",
+    "\n",
+    "try:\n",
+    "    trajectory = planner.plan_to_joint_configuration(q_start, q_goal)\n",
+    "    print(f\"Planned {len(trajectory.path.positions)} waypoints\")\n",
+    "except NoPathFoundError:\n",
+    "    print(\"Planning failed against collision_test.yml - diagnosing below.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000017",
+   "metadata": {},
+   "source": [
+    "### Diagnosing a failure that self-collision didn't predict\n",
+    "\n",
+    "Since `RobotDebugger` (step 5) already ruled out self-collision, the next question is whether this is a *world*-collision (fitted spheres bulging into the scene's obstacles) or something else. Isolate it by re-running the identical plan with **no** world obstacles at all - if that succeeds, the fitted spheres themselves are fine in isolation, and the problem is specifically their size/placement relative to this particular scene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from curobo.motion_planner import MotionPlanner, MotionPlannerCfg\n",
+    "from curobo.types import JointState\n",
+    "\n",
+    "empty_world_config = MotionPlannerCfg.create(robot=output_path, use_cuda_graph=False)  # no scene_model\n",
+    "empty_world_planner = MotionPlanner(empty_world_config)\n",
+    "empty_world_planner.warmup(num_warmup_iterations=1)\n",
+    "\n",
+    "start_js = JointState.from_position(\n",
+    "    torch.tensor(q_start, dtype=torch.float32)[None, :].cuda(), joint_names=empty_world_planner.joint_names\n",
+    ")\n",
+    "goal_js = JointState.from_position(\n",
+    "    torch.tensor(q_goal, dtype=torch.float32)[None, :].cuda(), joint_names=empty_world_planner.joint_names\n",
+    ")\n",
+    "result = empty_world_planner.plan_cspace(goal_js, start_js)\n",
+    "print(\"Plan succeeds with an empty world:\", result is not None and bool(result.success.any()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000019",
+   "metadata": {},
+   "source": [
+    "This confirms it: the fitted spheres are collision-free with an empty world, so the failure above is specifically about this sphere fit intersecting `collision_test.yml`'s obstacles at the tested poses - a scene/sphere-margin issue, not a bug in the config or the planner.\n",
+    "\n",
+    "**This is expected, not a dead end** - it's exactly why step 6 matters: auto-fit spheres are a conservative approximation and won't always match the tighter margins of a hand-tuned config like the bundled `ur10e.yml`. From here, the fix is iterative and scene-specific:\n",
+    "- Test against *your actual* scene, not an unrelated bundled one like `collision_test.yml` (which was tuned around a Franka Panda's geometry, not a UR10e's).\n",
+    "- If it's still too conservative for your scene, try lowering `sphere_density` or `clip_links` for the specific link that's closest to the obstacle in step 2 (use the per-link `coverage`/`protrusion` metrics, or `RobotDebugger`, to judge fit quality - **not** `builder.visualize(show_meshes=True)`, which is unreliable, see step 2), then repeat steps 3-6.\n",
+    "- Re-run this section after any refit - there's no shortcut to re-verifying against your real scene."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/07_curobo_custom_robot.ipynb
+++ b/notebooks/07_curobo_custom_robot.ipynb
@@ -9,9 +9,7 @@
     "\n",
     "cuRobo only ships a handful of example robot configs by name (`franka.yml`, `ur10e.yml`, `dual_ur10e.yml`, `unitree_g1.yml`, ...). If your robot isn't one of these, you need to build your own config from a URDF - including fitting collision spheres yourself, since cuRobo represents robot links as spheres for fast GPU collision checking.\n",
     "\n",
-    "cuRobo v2 ships a first-party `RobotBuilder` (`curobo.robot_builder`) for this, replacing the old external \"bubblify\" tool from cuRobo v1. This notebook walks through the whole pipeline using cuRobo's bundled `ur10e.urdf` as a concrete, runnable example - the same steps apply to any URDF of your own.\n",
-    "\n",
-    "**Every step below was actually run against a real GPU while writing this notebook** - including two real gotchas in `RobotBuilder` that aren't documented upstream (see the cells marked ⚠️), and a genuine diagnostic walkthrough at the end where planning fails for real and we work out why."
+    "cuRobo v2 ships a first-party `RobotBuilder` (`curobo.robot_builder`) for this, replacing the old external \"bubblify\" tool from cuRobo v1. This notebook walks through the whole pipeline, first with cuRobo's bundled `ur10e.urdf` as a minimal single-URDF example, then with a more realistic combined URDF - a Realman RM75-6F arm with a Schunk EGK40 Magneto gripper and a wrist-mounted RealSense D435 camera, all from [`airo-models`](https://github.com/airo-ugent/airo-models) - as the concrete, runnable end-to-end example. The same steps apply to any URDF of your own.\n"
    ]
   },
   {
@@ -32,7 +30,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000003",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:27:44.128779Z",
+     "iopub.status.busy": "2026-07-07T14:27:44.128567Z",
+     "iopub.status.idle": "2026-07-07T14:27:44.133993Z",
+     "shell.execute_reply": "2026-07-07T14:27:44.133031Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -59,30 +64,165 @@
    "source": [
     "### Using an `airo-models` URDF instead\n",
     "\n",
-    "`airo_models.get_urdf_path(name)` returns the absolute path to a bundled URDF (e.g. `\"ur3e\"`, `\"ur5e\"`, `\"robotiq_2f_85\"`). Unlike cuRobo's own robots (which keep meshes in a shared `meshes/<robot>/visual/...` subdirectory), `airo-models` keeps each URDF next to its own `visual/`/`collision/` mesh folders - so the asset path `RobotBuilder` needs is simply the URDF's own parent directory. This was verified end-to-end (mesh loading, sphere fitting, self-collision matrix, and actual planning with `SingleArmCuroboPlanner`) against `airo_models`' bundled UR3e:"
+    "`airo_models.get_urdf_path(name)` returns the absolute path to a bundled URDF (e.g. `\"ur3e\"`, `\"rm75_6f\"`, `\"schunk_egk40_magneto\"`). Unlike cuRobo's own robots (which keep meshes in a shared `meshes/<robot>/visual/...` subdirectory), `airo-models` keeps each URDF next to its own `visual/`/`collision/` mesh folders - so the asset path `RobotBuilder` needs is simply the URDF's own parent directory. This was verified end-to-end (mesh loading, sphere fitting, self-collision matrix, and actual planning with `SingleArmCuroboPlanner`) against `airo_models`' bundled Realman RM75-6F arm:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "c171facf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:27:44.136390Z",
+     "iopub.status.busy": "2026-07-07T14:27:44.136035Z",
+     "iopub.status.idle": "2026-07-07T14:27:44.145844Z",
+     "shell.execute_reply": "2026-07-07T14:27:44.144840Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "import airo_models\n",
+    "print(\"Available airo_models:\", airo_models.AIRO_MODEL_NAMES)\n",
     "\n",
-    "airo_models_urdf_path = airo_models.get_urdf_path(\"ur3e\")\n",
+    "\n",
+    "airo_models_urdf_path = airo_models.get_urdf_path(\"rm75_6f\")\n",
     "airo_models_asset_path = os.path.dirname(airo_models_urdf_path)  # URDF's own directory, not a \"meshes/\" subfolder\n",
     "\n",
     "print(airo_models_urdf_path)\n",
+    "urdf_path = airo_models_urdf_path\n",
+    "asset_path = airo_models_asset_path\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52fa7175",
+   "metadata": {},
+   "source": [
+    "### Combining arm + gripper + camera into a single URDF\n",
     "\n",
-    "# Note: airo_models.AIRO_MODEL_NAMES only lists a subset (arms); get_urdf_path also accepts grippers,\n",
-    "# cameras, mobile-platform parts, and mounting plates - check airo_models/files.py for the full list.\n",
+    "`RobotBuilder` takes one URDF. If your robot is an arm with an attached gripper and/or a wrist camera, you need to merge them before building the sphere config.\n",
     "\n",
-    "# To actually use it instead of the ur10e.urdf example below, uncomment:\n",
-    "# urdf_path, asset_path = airo_models_urdf_path, airo_models_asset_path"
+    "The steps below combine the RM75-6F arm with the Schunk EGK40 Magneto gripper (parallel gripper with magnetic fingertips) and a wrist-mounted RealSense D435, using the same `attach_urdf` calls and mounting values as `airo-models`' own `scripts/combine_urdf_example.py`:\n",
+    "1. Load each component URDF from `airo_models` and make all mesh paths absolute (so the merged file resolves them regardless of where it's written).\n",
+    "2. Freeze gripper and camera joints with `make_static` – cuRobo plans only the arm's DOF; the gripper and camera are treated as rigid attached links.\n",
+    "3. Prefix every link/joint name (`schunk_`, `d435_`) to avoid name collisions in the merged URDF.\n",
+    "4. Merge all links and joints, then add three fixed attaching joints:\n",
+    "   - arm `tool0` → `schunk_base_link` (gripper at flange)\n",
+    "   - arm `tool0` → `d435_base_link` (camera on wrist – **adjust the offset to match your physical bracket**)\n",
+    "   - `schunk_base_link` → `schunk_tcp` (virtual tip between finger mounts, used as planning target)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca28fc2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:27:44.147887Z",
+     "iopub.status.busy": "2026-07-07T14:27:44.147690Z",
+     "iopub.status.idle": "2026-07-07T14:27:44.162176Z",
+     "shell.execute_reply": "2026-07-07T14:27:44.161202Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import airo_models\n",
+    "from airo_models import urdf as urdf_utils\n",
+    "from airo_models.urdf import attach_urdf\n",
+    "\n",
+    "# --- Load each component ---\n",
+    "arm_urdf_path = airo_models.get_urdf_path(\"rm75_6f\")\n",
+    "gripper_urdf_path = airo_models.get_urdf_path(\"schunk_egk40_magneto\")\n",
+    "camera_urdf_path = airo_models.get_urdf_path(\"d435\")\n",
+    "\n",
+    "arm_dict = urdf_utils.read_urdf(str(arm_urdf_path))\n",
+    "urdf_utils.make_paths_absolute(arm_dict, str(arm_urdf_path))\n",
+    "\n",
+    "gripper_dict = urdf_utils.read_urdf(str(gripper_urdf_path))\n",
+    "camera_dict = urdf_utils.read_urdf(str(camera_urdf_path))\n",
+    "\n",
+    "# Attach the gripper to the arm flange. attachment_urdf_path makes mesh paths absolute before\n",
+    "# merging. freeze_joints=True (default) converts gripper joints to fixed - cuRobo plans only\n",
+    "# the arm's DOF.\n",
+    "attach_urdf(arm_dict, gripper_dict, parent_link=\"tool0\", child_prefix=\"schunk_\",\n",
+    "            attachment_urdf_path=str(gripper_urdf_path))\n",
+    "\n",
+    "# Wrist camera: 5 cm along tool0 y-axis, tilted 30° (π/6) downward around the x-axis so the\n",
+    "# optical axis (camera Z+) points toward the gripper fingertips - mounting values reused as-is\n",
+    "# from airo-models' combine_urdf_example.py.\n",
+    "attach_urdf(arm_dict, camera_dict, parent_link=\"tool0\", child_prefix=\"d435_\",\n",
+    "            attachment_urdf_path=str(camera_urdf_path),\n",
+    "            origin_xyz=\"0.02 0.05 0.06\", origin_rpy=\"-0.3 0 3.14\")  # ← adjust xyz/rpy for your physical bracket\n",
+    "\n",
+    "# Virtual TCP at the tip of the gripper body (between finger mounts); used as the planning target.\n",
+    "arm_dict[\"robot\"][\"link\"].append({\"@name\": \"schunk_tcp\"})\n",
+    "arm_dict[\"robot\"][\"joint\"].append({\n",
+    "    \"@name\": \"gripper_to_tcp\",\n",
+    "    \"@type\": \"fixed\",\n",
+    "    \"parent\": {\"@link\": \"schunk_base_link\"},\n",
+    "    \"child\": {\"@link\": \"schunk_tcp\"},\n",
+    "    \"origin\": {\"@xyz\": \"0 0 0.0835\", \"@rpy\": \"0 0 0\"},\n",
+    "})\n",
+    "\n",
+    "# --- Write combined URDF ---\n",
+    "combined_urdf_path = \"/tmp/rm75_6f_schunk_magneto_d435.urdf\"\n",
+    "urdf_utils.write_urdf_to_file(arm_dict, combined_urdf_path)\n",
+    "urdf_path = combined_urdf_path\n",
+    "asset_path = \"\"  # all mesh paths are now absolute\n",
+    "print(f\"Combined URDF written to: {combined_urdf_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e61e57b",
+   "metadata": {},
+   "source": [
+    "### Gotcha: links with mass but no `<inertia>` tensor crash the parser\n",
+    "\n",
+    "Several links in the Magneto gripper URDF (`base_link`, `camera_mount_plate`, `pcb_mount_plate`, `base_link_gripper`, both fingers) declare `<inertial><mass .../></inertial>` with a mass but **no `<inertia>` tensor**. cuRobo's URDF parser (via `yourdfpy`) treats \"no `<inertial>` element at all\" and \"`<inertial>` present but missing `<inertia>`\" very differently: the former falls back to a small default inertia, but the latter leaves `inertial.inertia = None` and crashes later with `TypeError: 'NoneType' object is not subscriptable` inside `RobotBuilder.compute_collision_matrix()`. This is real, reproducible - not a hypothetical - and isn't specific to `RobotBuilder`; any cuRobo pipeline that parses this URDF hits it.\n",
+    "\n",
+    "The fix: patch a small placeholder `<inertia>` tensor onto every link that has `<inertial>` but is missing it, before handing the merged URDF to `RobotBuilder`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8d2c237",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:27:44.164514Z",
+     "iopub.status.busy": "2026-07-07T14:27:44.164300Z",
+     "iopub.status.idle": "2026-07-07T14:27:44.172687Z",
+     "shell.execute_reply": "2026-07-07T14:27:44.171938Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def patch_missing_inertia_tensors(urdf_dict: dict) -> int:\n",
+    "    \"\"\"Add a small placeholder <inertia> tensor to every link with <inertial> but no <inertia>.\n",
+    "\n",
+    "    Returns the number of links patched.\n",
+    "    \"\"\"\n",
+    "    links = urdf_dict[\"robot\"][\"link\"]\n",
+    "    if isinstance(links, dict):\n",
+    "        links = [links]\n",
+    "    n_patched = 0\n",
+    "    for link in links:\n",
+    "        inertial = link.get(\"inertial\")\n",
+    "        if inertial is not None and \"inertia\" not in inertial:\n",
+    "            inertial[\"inertia\"] = {\n",
+    "                \"@ixx\": \"1e-4\", \"@iyy\": \"1e-4\", \"@izz\": \"1e-4\",\n",
+    "                \"@ixy\": \"0\", \"@ixz\": \"0\", \"@iyz\": \"0\",\n",
+    "            }\n",
+    "            n_patched += 1\n",
+    "    return n_patched\n",
+    "\n",
+    "\n",
+    "n_patched = patch_missing_inertia_tensors(arm_dict)\n",
+    "print(f\"Patched missing <inertia> tensors on {n_patched} links\")\n",
+    "urdf_utils.write_urdf_to_file(arm_dict, combined_urdf_path)  # re-write with the patched inertials\n"
    ]
   },
   {
@@ -92,46 +232,47 @@
    "source": [
     "## 2. Create the builder and fit collision spheres\n",
     "\n",
-    "`fit_collision_spheres` approximates each link's mesh with a set of spheres. `sphere_density` controls how many spheres per link (practical range 0.1-10.0); `compute_metrics=True` reports fit quality (`coverage` close to 1.0 is good, high `protrusion` means spheres bulge outside the mesh)."
+    "`fit_collision_spheres` approximates each link's mesh with a set of spheres. We pass `use_collision_mesh=True` so the spheres are fit to each link's `<collision>` geometry rather than the (default) `<visual>` geometry: the collision meshes are the simplified, convex-decomposed hulls intended for collision checking, so they give tighter, cheaper sphere fits and match the geometry the planner actually reasons about. `sphere_density` controls how many spheres per link (practical range 0.1-10.0); `compute_metrics=True` reports fit quality (`coverage` close to 1.0 is good, high `protrusion` means spheres bulge outside the mesh).\n",
+    "\n",
+    "We also clip the **first link that has a `<collision>` element** at `z=0` via `clip_links`. That link is the robot's mounting base, so any spheres poking below its `z=0` mounting plane would spuriously collide with the surface the robot is mounted on. We skip pure virtual/inertia-only links (no collision geometry) since `RobotBuilder` ignores them anyway.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000005",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:27:44.174481Z",
+     "iopub.status.busy": "2026-07-07T14:27:44.174293Z",
+     "iopub.status.idle": "2026-07-07T14:28:25.811263Z",
+     "shell.execute_reply": "2026-07-07T14:28:25.810146Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from curobo.robot_builder import RobotBuilder\n",
     "\n",
-    "builder = RobotBuilder(str(urdf_path), str(asset_path), tool_frames=[\"tool0\"])\n",
-    "builder.fit_collision_spheres(sphere_density=1.0, compute_metrics=True)\n",
+    "from airo_models import urdf as urdf_utils\n",
+    "\n",
+    "# Clip the first link that has a <collision> element at z=0 so its spheres don't dip below\n",
+    "# the mounting plane and spuriously collide with the surface the robot stands on.\n",
+    "# (Pure virtual/inertia-only links have no collision geometry and nothing to clip.)\n",
+    "links = urdf_utils.read_urdf(str(urdf_path))[\"robot\"][\"link\"]\n",
+    "first_collision_link = next(l[\"@name\"] for l in links if \"collision\" in l)\n",
+    "print(f\"First link with collision geometry: {first_collision_link}\")\n",
+    "\n",
+    "builder = RobotBuilder(str(urdf_path), str(asset_path), tool_frames=[\"schunk_tcp\"])\n",
+    "builder.fit_collision_spheres(\n",
+    "    sphere_density=3.0,\n",
+    "    use_collision_mesh=True,\n",
+    "    clip_links={first_collision_link: (\"z\", 0.0)},\n",
+    "    compute_metrics=True,\n",
+    ")\n",
     "\n",
     "print(f\"Fitted {builder.num_spheres} spheres across {len(builder.collision_link_names)} links\")\n",
     "for link, metrics in builder.link_metrics.items():\n",
-    "    print(f\"  {link}: {metrics.num_spheres} spheres, coverage={metrics.coverage:.2f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4-0001-0001-0001-000000000006",
-   "metadata": {},
-   "source": [
-    "### Optional: inspect the fit interactively\n",
-    "\n",
-    "`builder.visualize()` opens an interactive Viser viewer so you can see the fitted spheres against the robot. **It blocks the cell** until `timeout_sec` elapses (or forever if you don't pass one) - open the printed URL in your browser, then either wait for the timeout or interrupt the cell when you're done looking.\n",
-    "\n",
-    "⚠️ **Gotcha:** `show_meshes=True` is unreliable - don't use it to judge sphere fit quality. Each link's mesh is added as a flat, static Viser node positioned at that mesh's local `<visual>` origin *from the URDF*, without ever being passed through the robot's actual kinematic chain (confirmed by reading `RobotBuilder.visualize()`'s and `ViserVisualizer.add_mesh()`'s source). Only the base link's mesh ends up near its correct world position by coincidence; every other link's mesh appears frozen at the wrong place, visibly detached from the correctly-posed sphere set and skeleton (which *do* go through forward kinematics). Leave `show_meshes=False` (the default) and rely on the `coverage`/`protrusion` metrics from step 2, or `RobotDebugger`, instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a1b2c3d4-0001-0001-0001-000000000007",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# builder.visualize(timeout_sec=30)  # uncomment to try it - leave show_meshes at its default (False)"
+    "    print(f\"  {link}: {metrics.num_spheres} spheres, coverage={metrics.coverage:.2f}\")\n"
    ]
   },
   {
@@ -141,12 +282,50 @@
    "source": [
     "If a specific link's fit is bad, refit just that link instead of the whole robot:\n",
     "```python\n",
-    "builder.refit_link_spheres(\"wrist_3_link\", sphere_density=2.0)\n",
+    "builder.refit_link_spheres(\"link_6\", sphere_density=2.0)\n",
     "```\n",
     "or clip spheres away from one side of a link (e.g. to avoid the base link's spheres poking below the mounting plate):\n",
     "```python\n",
-    "builder.fit_collision_spheres(clip_links={\"base_link_inertia\": (\"z\", 0.0)})\n",
+    "builder.fit_collision_spheres(clip_links={\"base_link\": (\"z\", 0.0)}, use_collision_mesh=True)\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c474d54f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder.refit_link_spheres(\"schunk_right_magneto_finger\",sphere_density=10.0)\n",
+    "builder.refit_link_spheres(\"schunk_left_magneto_finger\",sphere_density=10.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000006",
+   "metadata": {},
+   "source": [
+    "### Optional: inspect the fit interactively\n",
+    "\n",
+    "`builder.visualize()` opens an interactive Viser viewer so you can see the fitted spheres against the robot. **It blocks the cell** until `timeout_sec` elapses (or forever if you don't pass one) - open the printed URL in your browser, then either wait for the timeout or interrupt the cell when you're done looking.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0001-0001-0001-000000000007",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:28:25.815622Z",
+     "iopub.status.busy": "2026-07-07T14:28:25.815280Z",
+     "iopub.status.idle": "2026-07-07T14:28:57.130898Z",
+     "shell.execute_reply": "2026-07-07T14:28:57.129136Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "builder.visualize(timeout_sec=30)"
    ]
   },
   {
@@ -165,7 +344,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000010",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:28:57.135670Z",
+     "iopub.status.busy": "2026-07-07T14:28:57.134932Z",
+     "iopub.status.idle": "2026-07-07T14:29:35.956918Z",
+     "shell.execute_reply": "2026-07-07T14:29:35.956281Z"
+    }
+   },
    "outputs": [],
    "source": [
     "builder.compute_collision_matrix(num_samples=1000)\n",
@@ -186,13 +372,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000012",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:29:35.958761Z",
+     "iopub.status.busy": "2026-07-07T14:29:35.958512Z",
+     "iopub.status.idle": "2026-07-07T14:29:36.264133Z",
+     "shell.execute_reply": "2026-07-07T14:29:36.262931Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import yaml\n",
     "\n",
     "config = builder.build()\n",
-    "output_path = \"/tmp/ur10e_custom.yml\"\n",
+    "output_path = \"/tmp/rm75_6f_schunk_magneto_d435.yml\"\n",
     "builder.save(config, output_path)\n",
     "\n",
     "# Work around the load_collision_spheres/num_envs bug described above.\n",
@@ -218,7 +411,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000014",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:29:36.266878Z",
+     "iopub.status.busy": "2026-07-07T14:29:36.266705Z",
+     "iopub.status.idle": "2026-07-07T14:29:36.475520Z",
+     "shell.execute_reply": "2026-07-07T14:29:36.474300Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from curobo.robot_builder import RobotDebugger\n",
@@ -238,14 +438,21 @@
    "source": [
     "## 6. Use it with `SingleArmCuroboPlanner`\n",
     "\n",
-    "This is the real end-to-end test - self-collision passing (step 5) does **not** guarantee the robot won't collide with *your scene*. In fact, with this notebook's default `sphere_density=1.0` fit for the UR10e, planning against cuRobo's bundled `collision_test.yml` scene genuinely fails below, even though self-collision was clean - this is real, reproducible behavior, not a hypothetical."
+    "This is the real end-to-end test - self-collision passing (step 5) does **not** guarantee the robot won't collide with *your scene*. Below we plan against cuRobo's bundled `collision_test.yml` scene as a smoke test. This particular scene happens to be tuned around a Franka Panda's geometry, not the RM75-6F's, so a pass here is not a substitute for testing against your actual scene - see the optional diagnostic section below for what to do if planning *does* fail for you."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000016",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:29:36.478755Z",
+     "iopub.status.busy": "2026-07-07T14:29:36.478593Z",
+     "iopub.status.idle": "2026-07-07T14:30:05.245872Z",
+     "shell.execute_reply": "2026-07-07T14:30:05.244261Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from airo_planner import NoPathFoundError\n",
@@ -256,7 +463,11 @@
     "q_start = planner.motion_planner.default_joint_state.position.cpu().numpy()\n",
     "q_goal = q_start.copy()\n",
     "q_goal[0] += 0.5\n",
-    "q_goal[1] += 0.3\n",
+    "q_goal[1] = 0.5\n",
+    "q_goal[3] = 1.6\n",
+    "q_goal[5] = 0.5\n",
+    "q_goal[6] = 0.6\n",
+    "\n",
     "\n",
     "try:\n",
     "    trajectory = planner.plan_to_joint_configuration(q_start, q_goal)\n",
@@ -266,20 +477,80 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37471683",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:30:05.249937Z",
+     "iopub.status.busy": "2026-07-07T14:30:05.249413Z",
+     "iopub.status.idle": "2026-07-07T14:30:05.971830Z",
+     "shell.execute_reply": "2026-07-07T14:30:05.971034Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import torch\n",
+    "from curobo.viewer import ViserVisualizer\n",
+    "from curobo.types import ContentPath, JointState\n",
+    "\n",
+    "viz = ViserVisualizer(content_path=ContentPath(robot_config_file=output_path), add_control_frames=True)\n",
+    "\n",
+    "\n",
+    "def playback(trajectory):\n",
+    "    \"\"\"Play back a SingleArmTrajectory in the Viser viewer, respecting its timestamps.\"\"\"\n",
+    "    t = 0.0\n",
+    "    for i, q in enumerate(trajectory.path.positions):\n",
+    "        joint_state = JointState.from_position(\n",
+    "            torch.tensor(q, dtype=torch.float32)[None, :].cuda(), joint_names=planner.motion_planner.joint_names\n",
+    "        ).squeeze(0)\n",
+    "        viz.set_joint_state(joint_state)\n",
+    "        time.sleep(max(0.0, trajectory.times[i] - t))\n",
+    "        t = trajectory.times[i]\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "170f0f83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:30:05.974193Z",
+     "iopub.status.busy": "2026-07-07T14:30:05.974004Z",
+     "iopub.status.idle": "2026-07-07T14:30:07.518733Z",
+     "shell.execute_reply": "2026-07-07T14:30:07.516801Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "playback(trajectory)\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a1b2c3d4-0001-0001-0001-000000000017",
    "metadata": {},
    "source": [
-    "### Diagnosing a failure that self-collision didn't predict\n",
+    "### Optional: diagnosing a failure that self-collision didn't predict\n",
     "\n",
-    "Since `RobotDebugger` (step 5) already ruled out self-collision, the next question is whether this is a *world*-collision (fitted spheres bulging into the scene's obstacles) or something else. Isolate it by re-running the identical plan with **no** world obstacles at all - if that succeeds, the fitted spheres themselves are fine in isolation, and the problem is specifically their size/placement relative to this particular scene."
+    "If planning against your scene fails even though `RobotDebugger` (step 5) ruled out self-collision, the next question is whether this is a *world*-collision (fitted spheres bulging into the scene's obstacles) or something else. Isolate it by re-running the identical plan with **no** world obstacles at all - if that succeeds, the fitted spheres themselves are fine in isolation, and the problem is specifically their size/placement relative to this particular scene. This section runs regardless of whether step 6 above passed, as a demonstration of the technique."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000018",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T14:30:07.523492Z",
+     "iopub.status.busy": "2026-07-07T14:30:07.523023Z",
+     "iopub.status.idle": "2026-07-07T14:30:12.750651Z",
+     "shell.execute_reply": "2026-07-07T14:30:12.749130Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import torch\n",
@@ -305,18 +576,18 @@
    "id": "a1b2c3d4-0001-0001-0001-000000000019",
    "metadata": {},
    "source": [
-    "This confirms it: the fitted spheres are collision-free with an empty world, so the failure above is specifically about this sphere fit intersecting `collision_test.yml`'s obstacles at the tested poses - a scene/sphere-margin issue, not a bug in the config or the planner.\n",
+    "The empty-world plan above confirms the fitted spheres are collision-free in isolation. If step 6 *did* fail for you, this pinpoints the cause as the sphere fit intersecting the scene's obstacles at the tested poses - a scene/sphere-margin issue, not a bug in the config or the planner.\n",
     "\n",
-    "**This is expected, not a dead end** - it's exactly why step 6 matters: auto-fit spheres are a conservative approximation and won't always match the tighter margins of a hand-tuned config like the bundled `ur10e.yml`. From here, the fix is iterative and scene-specific:\n",
-    "- Test against *your actual* scene, not an unrelated bundled one like `collision_test.yml` (which was tuned around a Franka Panda's geometry, not a UR10e's).\n",
-    "- If it's still too conservative for your scene, try lowering `sphere_density` or `clip_links` for the specific link that's closest to the obstacle in step 2 (use the per-link `coverage`/`protrusion` metrics, or `RobotDebugger`, to judge fit quality - **not** `builder.visualize(show_meshes=True)`, which is unreliable, see step 2), then repeat steps 3-6.\n",
+    "If it's too conservative for your scene, the fix is iterative and scene-specific:\n",
+    "- Test against *your actual* scene, not an unrelated bundled one like `collision_test.yml`.\n",
+    "- Try lowering `sphere_density` or `clip_links` for the specific link closest to the obstacle in step 2 (use the per-link `coverage`/`protrusion` metrics, or `RobotDebugger`, to judge fit quality - **not** `builder.visualize(show_meshes=True)`, which is unreliable, see step 2), then repeat steps 3-6.\n",
     "- Re-run this section after any refit - there's no shortcut to re-verifying against your real scene."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "airo-planner (3.12.13.final.0)",
    "language": "python",
    "name": "python3"
   },
@@ -330,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/07_curobo_custom_robot.ipynb
+++ b/notebooks/07_curobo_custom_robot.ipynb
@@ -30,14 +30,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000003",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:27:44.128779Z",
-     "iopub.status.busy": "2026-07-07T14:27:44.128567Z",
-     "iopub.status.idle": "2026-07-07T14:27:44.133993Z",
-     "shell.execute_reply": "2026-07-07T14:27:44.133031Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -71,14 +64,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c171facf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:27:44.136390Z",
-     "iopub.status.busy": "2026-07-07T14:27:44.136035Z",
-     "iopub.status.idle": "2026-07-07T14:27:44.145844Z",
-     "shell.execute_reply": "2026-07-07T14:27:44.144840Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -118,14 +104,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ca28fc2e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:27:44.147887Z",
-     "iopub.status.busy": "2026-07-07T14:27:44.147690Z",
-     "iopub.status.idle": "2026-07-07T14:27:44.162176Z",
-     "shell.execute_reply": "2026-07-07T14:27:44.161202Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import airo_models\n",
@@ -190,14 +169,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a8d2c237",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:27:44.164514Z",
-     "iopub.status.busy": "2026-07-07T14:27:44.164300Z",
-     "iopub.status.idle": "2026-07-07T14:27:44.172687Z",
-     "shell.execute_reply": "2026-07-07T14:27:44.171938Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def patch_missing_inertia_tensors(urdf_dict: dict) -> int:\n",
@@ -241,14 +213,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000005",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:27:44.174481Z",
-     "iopub.status.busy": "2026-07-07T14:27:44.174293Z",
-     "iopub.status.idle": "2026-07-07T14:28:25.811263Z",
-     "shell.execute_reply": "2026-07-07T14:28:25.810146Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from curobo.robot_builder import RobotBuilder\n",
@@ -315,14 +280,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000007",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:28:25.815622Z",
-     "iopub.status.busy": "2026-07-07T14:28:25.815280Z",
-     "iopub.status.idle": "2026-07-07T14:28:57.130898Z",
-     "shell.execute_reply": "2026-07-07T14:28:57.129136Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "builder.visualize(timeout_sec=30)"
@@ -344,14 +302,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000010",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:28:57.135670Z",
-     "iopub.status.busy": "2026-07-07T14:28:57.134932Z",
-     "iopub.status.idle": "2026-07-07T14:29:35.956918Z",
-     "shell.execute_reply": "2026-07-07T14:29:35.956281Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "builder.compute_collision_matrix(num_samples=1000)\n",
@@ -372,14 +323,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000012",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:29:35.958761Z",
-     "iopub.status.busy": "2026-07-07T14:29:35.958512Z",
-     "iopub.status.idle": "2026-07-07T14:29:36.264133Z",
-     "shell.execute_reply": "2026-07-07T14:29:36.262931Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import yaml\n",
@@ -411,14 +355,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000014",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:29:36.266878Z",
-     "iopub.status.busy": "2026-07-07T14:29:36.266705Z",
-     "iopub.status.idle": "2026-07-07T14:29:36.475520Z",
-     "shell.execute_reply": "2026-07-07T14:29:36.474300Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from curobo.robot_builder import RobotDebugger\n",
@@ -445,14 +382,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000016",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:29:36.478755Z",
-     "iopub.status.busy": "2026-07-07T14:29:36.478593Z",
-     "iopub.status.idle": "2026-07-07T14:30:05.245872Z",
-     "shell.execute_reply": "2026-07-07T14:30:05.244261Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from airo_planner import NoPathFoundError\n",
@@ -480,14 +410,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "37471683",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:30:05.249937Z",
-     "iopub.status.busy": "2026-07-07T14:30:05.249413Z",
-     "iopub.status.idle": "2026-07-07T14:30:05.971830Z",
-     "shell.execute_reply": "2026-07-07T14:30:05.971034Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
@@ -516,14 +439,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "170f0f83",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:30:05.974193Z",
-     "iopub.status.busy": "2026-07-07T14:30:05.974004Z",
-     "iopub.status.idle": "2026-07-07T14:30:07.518733Z",
-     "shell.execute_reply": "2026-07-07T14:30:07.516801Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "playback(trajectory)\n"
@@ -543,14 +459,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0001-0001-0001-000000000018",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-07T14:30:07.523492Z",
-     "iopub.status.busy": "2026-07-07T14:30:07.523023Z",
-     "iopub.status.idle": "2026-07-07T14:30:12.750651Z",
-     "shell.execute_reply": "2026-07-07T14:30:12.749130Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,6 @@ dependencies = [
 Homepage = "https://github.com/airo-ugent/airo-planner"
 Issues = "https://github.com/airo-ugent/airo-planner/issues"
 
-[project.optional-dependencies]
-rerun = [
-    "rerun-sdk>=0.27.2",
-]
-
 [dependency-groups]
 dev = [
     "jupyter>=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airo-planner"
-version = "0.0.7"
+version = "0.0.9"
 authors = [
   { name = "Andreas Verleysen", email = "andreas.verleysen@ugent.be" },
   { name = "Victor-Louis De Gusseme", email = "victorlouisdg@gmail.com" },

--- a/test/curobo/single_arm/test_curobo_basic_planning.py
+++ b/test/curobo/single_arm/test_curobo_basic_planning.py
@@ -1,0 +1,53 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+if not torch.cuda.is_available():
+    pytest.skip("cuRobo tests require a CUDA-enabled GPU.", allow_module_level=True)
+
+pytest.importorskip("curobo")
+
+from curobo.scene import Cuboid  # noqa: E402
+
+from airo_planner import NoPathFoundError  # noqa: E402
+from airo_planner.curobo.single_arm_curobo_planner import SingleArmCuroboPlanner  # noqa: E402
+
+ROBOT_FILE = "ur10e.yml"
+WORLD_FILE = "collision_test.yml"
+
+
+def test_obstacle_free():
+    planner = SingleArmCuroboPlanner(ROBOT_FILE, WORLD_FILE)
+
+    start_configuration = planner.motion_planner.default_joint_state.position.cpu().numpy()
+    goal_configuration = start_configuration.copy()
+    goal_configuration[0] += 0.5
+    goal_configuration[1] += 0.3
+
+    trajectory = planner.plan_to_joint_configuration(start_configuration, goal_configuration)
+
+    assert len(trajectory.path.positions) > 0
+
+
+def test_blocked_by_obstacle():
+    planner = SingleArmCuroboPlanner(ROBOT_FILE, WORLD_FILE, max_attempts=2)
+
+    start_configuration = planner.motion_planner.default_joint_state.position.cpu().numpy()
+    goal_configuration = start_configuration.copy()
+    goal_configuration[0] += 0.5
+    goal_configuration[1] += 0.3
+    goal_tcp_pose = planner.forward_kinematics(goal_configuration)
+
+    # Enclose the goal TCP position in a large obstacle, so it cannot be reached collision-free.
+    obstacles = planner.get_collider_cuboids()
+    obstacles.append(
+        Cuboid(
+            name="blocker",
+            dims=[1.0, 1.0, 1.0],
+            pose=[goal_tcp_pose[0, 3], goal_tcp_pose[1, 3], goal_tcp_pose[2, 3], 1, 0, 0, 0],
+        )
+    )
+    planner.set_collider_cuboids(obstacles)
+
+    with pytest.raises(NoPathFoundError):
+        planner.plan_to_joint_configuration(start_configuration, goal_configuration)


### PR DESCRIPTION
cuRobo v1 was removed due to a licensing concern that no longer applies: v0.8.0 switched from a custom restrictive NVIDIA license to Apache 2.0. This re-adds SingleArmCuroboPlanner rebuilt against the real v2 API (verified end-to-end on GPU hardware, not just docs), plus getting-started and custom-robot-integration notebooks and a GPU-guarded test.